### PR TITLE
Add luxury poetry site layout and pages

### DIFF
--- a/kindly-kylie-starter-site-v2/about.html
+++ b/kindly-kylie-starter-site-v2/about.html
@@ -74,9 +74,12 @@
         <button class="menu-toggle" aria-controls="menu" aria-expanded="false">Menu</button>
         <ul id="menu">
           <li><a href="index.html">Home</a></li>
+          <li><a href="poems.html">Library</a></li>
+          <li><a href="commissions.html">Commissions</a></li>
+          <li><a href="shop.html">Shop</a></li>
+          <li><a href="spoken-word.html">Spoken Word</a></li>
           <li><a href="about.html">About</a></li>
-          <li><a href="services.html">Services</a></li>
-          <li><a href="projects.html">Projects</a></li>
+          <li><a href="blog.html">Blog</a></li>
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
@@ -86,7 +89,7 @@
   <main id="main">
   
 <section class="page-hero container">
-  <h1>About</h1>
+  <h1>About Kindly, Kylie</h1>
   <p><!-- 2–3 sentence overview of story, values, approach. --></p>
 </section>
 

--- a/kindly-kylie-starter-site-v2/blog.html
+++ b/kindly-kylie-starter-site-v2/blog.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Blog | Kindly, Kylie</title>
+  <meta name="description" content="Insights and updates from Kindly, Kylie.">
+  <link rel="icon" href="assets/favicon.ico">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png" sizes="180x180">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&family=Montserrat:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <header class="site-header">
+    <div class="container">
+      <a href="index.html" class="logo" aria-label="Go to home"></a>
+      <nav class="main-nav" aria-label="Primary">
+        <button class="menu-toggle" aria-controls="menu" aria-expanded="false">Menu</button>
+        <ul id="menu">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="poems.html">Library</a></li>
+          <li><a href="commissions.html">Commissions</a></li>
+          <li><a href="shop.html">Shop</a></li>
+          <li><a href="spoken-word.html">Spoken Word</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="page-hero container">
+      <h1>Blog</h1>
+      <p>Musings on craft, life, and literature.</p>
+    </section>
+
+    <section class="container">
+      <ul class="grid" style="list-style:none; padding:0; margin:0 0 2rem 0">
+        <li><a class="text-link" href="#">All</a></li>
+        <li><a class="text-link" href="#">Process</a></li>
+        <li><a class="text-link" href="#">Events</a></li>
+        <li><a class="text-link" href="#">Personal</a></li>
+      </ul>
+      <div class="grid cards" style="grid-template-columns:repeat(auto-fit,minmax(300px,1fr))">
+        <article class="card">
+          <img src="assets/social-share.jpg" alt="Blog post">
+          <h2>On Craft</h2>
+          <p class="excerpt">Thoughts on the discipline of daily writing.</p>
+        </article>
+        <article class="card">
+          <img src="assets/social-share.jpg" alt="Blog post">
+          <h2>Latest Event</h2>
+          <p class="excerpt">Recap from the most recent reading.</p>
+        </article>
+        <article class="card">
+          <img src="assets/social-share.jpg" alt="Blog post">
+          <h2>Notebook</h2>
+          <p class="excerpt">Fragments and inspirations from travels.</p>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="signature">
+        <picture>
+          <source srcset="assets/signature-kindly-kylie-800.webp 800w, assets/signature-kindly-kylie-400.webp 400w" type="image/webp">
+          <img src="assets/signature-kindly-kylie-400.jpg" alt="Kindly, Kylie signature" loading="lazy" width="400">
+        </picture>
+      </div>
+      <small>&copy; Kindly, Kylie</small>
+    </div>
+  </footer>
+
+  <script src="js/main.js" defer></script>
+</body>
+</html>

--- a/kindly-kylie-starter-site-v2/commissions.html
+++ b/kindly-kylie-starter-site-v2/commissions.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Commissions | Kindly, Kylie</title>
+  <meta name="description" content="Commission a bespoke poem from Kindly, Kylie.">
+  <link rel="icon" href="assets/favicon.ico">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png" sizes="180x180">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&family=Montserrat:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <header class="site-header">
+    <div class="container">
+      <a href="index.html" class="logo" aria-label="Go to home"></a>
+      <nav class="main-nav" aria-label="Primary">
+        <button class="menu-toggle" aria-controls="menu" aria-expanded="false">Menu</button>
+        <ul id="menu">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="poems.html">Library</a></li>
+          <li><a href="commissions.html">Commissions</a></li>
+          <li><a href="shop.html">Shop</a></li>
+          <li><a href="spoken-word.html">Spoken Word</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="page-hero container">
+      <h1>Commissions</h1>
+      <p>Custom poems penned for your milestones and muses.</p>
+    </section>
+
+    <section class="container">
+      <div class="grid cards">
+        <article class="card">
+          <h2>Short Verse</h2>
+          <p>A heartfelt stanza for notes and keepsakes.</p>
+          <p class="meta">$150</p>
+        </article>
+        <article class="card">
+          <h2>Full Poem</h2>
+          <p>An original piece up to 24 lines.</p>
+          <p class="meta">$350</p>
+        </article>
+        <article class="card">
+          <h2>Performance Piece</h2>
+          <p>Written for live readings or ceremonies.</p>
+          <p class="meta">$500</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="container" style="margin-top:2rem">
+      <ol class="grid" style="list-style:decimal; padding-left:1.25rem;">
+        <li>Share your story</li>
+        <li>Approve a draft</li>
+        <li>Receive your poem</li>
+      </ol>
+    </section>
+
+    <section class="container" style="margin-top:2rem">
+      <form class="contact-form" action="mailto:you@yourdomain.com" method="post" enctype="text/plain">
+        <label> Name <input type="text" name="name" required></label>
+        <label> Email <input type="email" name="email" required></label>
+        <label> Details <textarea name="details" rows="5"></textarea></label>
+        <button class="btn" type="submit">Request Poem</button>
+      </form>
+    </section>
+
+    <section class="container" style="margin-top:2rem">
+      <h2>Kind Words</h2>
+      <div class="card">
+        <p>“A beautiful keepsake we will treasure forever.”</p>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="signature">
+        <picture>
+          <source srcset="assets/signature-kindly-kylie-800.webp 800w, assets/signature-kindly-kylie-400.webp 400w" type="image/webp">
+          <img src="assets/signature-kindly-kylie-400.jpg" alt="Kindly, Kylie signature" loading="lazy" width="400">
+        </picture>
+      </div>
+      <small>&copy; Kindly, Kylie</small>
+    </div>
+  </footer>
+
+  <script src="js/main.js" defer></script>
+</body>
+</html>

--- a/kindly-kylie-starter-site-v2/contact.html
+++ b/kindly-kylie-starter-site-v2/contact.html
@@ -74,9 +74,12 @@
         <button class="menu-toggle" aria-controls="menu" aria-expanded="false">Menu</button>
         <ul id="menu">
           <li><a href="index.html">Home</a></li>
+          <li><a href="poems.html">Library</a></li>
+          <li><a href="commissions.html">Commissions</a></li>
+          <li><a href="shop.html">Shop</a></li>
+          <li><a href="spoken-word.html">Spoken Word</a></li>
           <li><a href="about.html">About</a></li>
-          <li><a href="services.html">Services</a></li>
-          <li><a href="projects.html">Projects</a></li>
+          <li><a href="blog.html">Blog</a></li>
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>

--- a/kindly-kylie-starter-site-v2/css/styles.css
+++ b/kindly-kylie-starter-site-v2/css/styles.css
@@ -6,9 +6,10 @@
   --cream:#F8F4E6;
   --taupe:#D9C9A6;
   --charcoal:#222222;
+  --content-width:1080px;
 }
 *{box-sizing:border-box}
-html{scroll-behavior:smooth}
+html{scroll-behavior:smooth;font-size:18px}
 body{
   margin:0;
   color:var(--charcoal);
@@ -16,10 +17,10 @@ body{
   font-family:Montserrat, system-ui, -apple-system, Segoe UI, Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif;
   line-height:1.6;
 }
-h1,h2,h3,h4{font-family:"Libre Baskerville", Georgia, "Times New Roman", serif; color:var(--green); line-height:1.25}
-a{color:var(--purple); text-decoration:none}
+h1,h2,h3,h4{font-family:"Libre Baskerville", Georgia, "Times New Roman", serif; color:var(--purple); line-height:1.25}
+a{color:var(--purple);text-decoration:none}
 a:hover{text-decoration:underline}
-.container{max-width:1100px; padding:0 1rem; margin:0 auto}
+.container{max-width:var(--content-width);padding:0 1rem;margin:0 auto}
 .site-header{background:#fff; border-bottom:1px solid rgba(0,0,0,.06); position:sticky; top:0; z-index:50}
 .site-header .container{display:flex; align-items:center; justify-content:space-between; min-height:64px}
 .logo{display:block; width:48px; height:48px; background:var(--taupe); border-radius:12px}
@@ -32,13 +33,24 @@ a:hover{text-decoration:underline}
 }
 .hero{padding:5rem 0 3rem}
 .subhead{max-width:60ch}
-.btn{display:inline-block; background:var(--green); color:#fff; padding:.75rem 1rem; border-radius:.75rem; border:2px solid var(--green)}
+.btn{display:inline-block;background:var(--green);color:#fff;padding:.75rem 1rem;border-radius:.75rem;border:2px solid var(--green)}
 .btn:hover{background:#16312c}
-.btn-outline{background:transparent; color:var(--green)}
+.btn-outline{background:transparent;color:var(--green);border-color:var(--green)}
+.gold-border{border:1px solid var(--gold)}
+.textured{background-image:url("../assets/paper-texture.jpg");background-size:cover;background-repeat:no-repeat}
+.poem{white-space:pre-wrap;font-family:"Libre Baskerville", Georgia, "Times New Roman", serif;line-height:1.8}
 .grid{display:grid; gap:1.25rem}
 .cards{grid-template-columns:repeat(auto-fit,minmax(240px,1fr))}
 .thumbs{grid-template-columns:repeat(auto-fit,minmax(260px,1fr))}
-.card{background:#fff; border:1px solid rgba(0,0,0,.08); border-radius:1rem; padding:1rem; box-shadow:0 10px 20px rgba(0,0,0,.04)}
+.card{background:#fff;border:1px solid var(--gold);border-radius:1rem;padding:1.5rem;box-shadow:0 4px 20px rgba(0,0,0,.06)}
+.feature-cards{display:grid;gap:2rem}
+.feature-cards .card{text-align:center}
+.latest-blog{display:grid;grid-template-columns:1fr 1fr;gap:2rem;align-items:center}
+@media(max-width:700px){.latest-blog{grid-template-columns:1fr}}
+.signup{background:var(--cream);padding:2rem 0;margin-top:3rem}
+.signup-form{display:flex;gap:1rem;flex-wrap:wrap}
+.signup-form input{flex:1 1 240px;padding:.75rem;border:1px solid var(--charcoal);border-radius:.5rem}
+.signup-form button{padding:.75rem 1.5rem}
 .page-hero{padding:3rem 0 1rem}
 .about-preview{display:grid; grid-template-columns:1fr 1fr; gap:2rem; align-items:center; padding:2rem 0}
 .about-detail{display:grid; grid-template-columns:1fr 1fr; gap:2rem; align-items:start; padding:2rem 0}

--- a/kindly-kylie-starter-site-v2/index.html
+++ b/kindly-kylie-starter-site-v2/index.html
@@ -1,83 +1,16 @@
 <!doctype html>
 <html lang="en">
 <head>
-<!-- BASIC SEO -->
-<title>PAGE TITLE | BRAND NAME</title>
-<meta name="description" content="1–2 sentence summary of THIS PAGE with a main keyword and benefit (~150–160 chars).">
-
-<!-- CANONICAL -->
-<link rel="canonical" href="https://WWW.YOURDOMAIN.COM/CURRENT-PAGE/">
-
-<!-- FAVICONS -->
-<link rel="icon" href="assets/favicon.ico">
-<link rel="apple-touch-icon" href="assets/apple-touch-icon.png" sizes="180x180">
-
-<!-- VIEWPORT -->
-<meta name="viewport" content="width=device-width, initial-scale=1">
-
-<!-- ROBOTS -->
-<meta name="robots" content="index,follow,max-snippet:-1,max-image-preview:large,max-video-preview:-1">
-
-<!-- OPEN GRAPH -->
-<meta property="og:type" content="website">
-<meta property="og:site_name" content="BRAND NAME">
-<meta property="og:title" content="PAGE TITLE | BRAND NAME">
-<meta property="og:description" content="Same (or slightly shorter) as meta description.">
-<meta property="og:url" content="https://WWW.YOURDOMAIN.COM/CURRENT-PAGE/">
-<meta property="og:image" content="https://WWW.YOURDOMAIN.COM/assets/social-share.jpg">
-<meta property="og:image:alt" content="Describe the social image for accessibility.">
-<meta property="og:locale" content="en_US">
-
-<!-- TWITTER CARD -->
-<meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="PAGE TITLE | BRAND NAME">
-<meta name="twitter:description" content="Same as meta description.">
-<meta name="twitter:image" content="https://WWW.YOURDOMAIN.COM/assets/social-share.jpg">
-
-<!-- FONTS -->
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&family=Montserrat:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-
-<link rel="stylesheet" href="css/styles.css">
-<!-- PAGE-SPECIFIC -->
-<title>MAIN KEYWORD / VALUE PROP | BRAND NAME</title>
-<meta name="description" content="Concise value statement: services, location, style + a clear benefit.">
-<link rel="canonical" href="https://WWW.YOURDOMAIN.COM/">
-<script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@graph": [
-    {
-      "@type": ["Organization"],
-      "name": "BRAND NAME",
-      "url": "https://WWW.YOURDOMAIN.COM/",
-      "logo": "https://WWW.YOURDOMAIN.COM/assets/logo.png",
-      "sameAs": [
-        "https://www.instagram.com/YOURPROFILE",
-        "https://www.linkedin.com/in/YOURPROFILE"
-      ],
-      "contactPoint": [{
-        "@type": "ContactPoint",
-        "contactType": "customer service",
-        "email": "YOU@YOURDOMAIN.COM",
-        "areaServed": "YOUR REGION/COUNTRY",
-        "availableLanguage": ["en"]
-      }]
-    },
-    {
-      "@type": "WebSite",
-      "name": "BRAND NAME",
-      "url": "https://WWW.YOURDOMAIN.COM/",
-      "potentialAction": {
-        "@type": "SearchAction",
-        "target": "https://WWW.YOURDOMAIN.COM/search?q={search_term_string}",
-        "query-input": "required name=search_term_string"
-      }
-    }
-  ]
-}
-</script>
+  <meta charset="utf-8">
+  <title>Kindly, Kylie | Luxury Poetry</title>
+  <meta name="description" content="The high-end poetry home of Kindly, Kylie. Explore the library, commission bespoke verses, and more.">
+  <link rel="icon" href="assets/favicon.ico">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png" sizes="180x180">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&family=Montserrat:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/styles.css">
 </head>
 <body>
   <a class="skip-link" href="#main">Skip to content</a>
@@ -88,9 +21,12 @@
         <button class="menu-toggle" aria-controls="menu" aria-expanded="false">Menu</button>
         <ul id="menu">
           <li><a href="index.html">Home</a></li>
+          <li><a href="poems.html">Library</a></li>
+          <li><a href="commissions.html">Commissions</a></li>
+          <li><a href="shop.html">Shop</a></li>
+          <li><a href="spoken-word.html">Spoken Word</a></li>
           <li><a href="about.html">About</a></li>
-          <li><a href="services.html">Services</a></li>
-          <li><a href="projects.html">Projects</a></li>
+          <li><a href="blog.html">Blog</a></li>
           <li><a href="contact.html">Contact</a></li>
         </ul>
       </nav>
@@ -99,69 +35,61 @@
 
   <main id="main">
   
-<section class="hero container">
-  <h1><!-- HERO HEADLINE: Replace with main headline --></h1>
-  <p class="subhead"><!-- HERO SUBHEAD: Replace with short value statement --></p>
-  <p>
-    <a class="btn" href="projects.html">View Projects</a>
-    <a class="btn btn-outline" href="contact.html">Contact</a>
-  </p>
+<section class="hero textured">
+    <div class="container">
+      <h1>Poetry for the Soul</h1>
+      <p class="subhead">Bespoke verses and spoken word performances by Kindly, Kylie.</p>
+      <p>
+        <a class="btn" href="commissions.html">Commission a Poem</a>
+        <a class="btn btn-outline" href="shop.html">Pre-order Book</a>
+      </p>
+    </div>
 </section>
 
-<section class="about-preview container">
-  <div class="about-media">
-    <picture>
-      <source srcset="assets/kylie-headshot-1200.webp 1200w, assets/kylie-headshot-600.webp 600w" type="image/webp">
-      <img src="assets/kylie-headshot-600.jpg" alt="<!-- Replace with descriptive alt text for headshot -->" loading="lazy" width="600">
-    </picture>
-  </div>
-  <div class="about-text">
-    <h2>About</h2>
-    <p><!-- ABOUT PARAGRAPH: 2–3 sentences: experience, approach, values. Mention city/region if local. --></p>
-    <a href="about.html" class="text-link">Read more</a>
-  </div>
+<section class="feature-cards container">
+  <article class="card">
+    <h2>Library</h2>
+    <p>A curated collection of original poems.</p>
+    <a class="text-link" href="poems.html">Enter the stacks</a>
+  </article>
+  <article class="card">
+    <h2>Commissions</h2>
+    <p>Handcrafted poems for treasured moments.</p>
+    <a class="text-link" href="commissions.html">Request yours</a>
+  </article>
+  <article class="card">
+    <h2>Spoken Word</h2>
+    <p>Bookings for intimate readings and events.</p>
+    <a class="text-link" href="spoken-word.html">Book a performance</a>
+  </article>
 </section>
 
-<section class="services container">
-  <h2>Services</h2>
-  <p><!-- SERVICES INTRO: 1 sentence: what you offer and who it’s for. --></p>
-  <div class="grid cards">
-    <article class="card">
-      <h3><!-- Service name --></h3>
-      <p><!-- Short description (1–2 lines) --></p>
-      <p class="meta"><!-- Optional starting price --></p>
-    </article>
-    <article class="card">
-      <h3><!-- Service name --></h3>
-      <p><!-- Short description (1–2 lines) --></p>
-      <p class="meta"><!-- Optional starting price --></p>
-    </article>
-    <article class="card">
-      <h3><!-- Service name --></h3>
-      <p><!-- Short description (1–2 lines) --></p>
-      <p class="meta"><!-- Optional starting price --></p>
-    </article>
+<section class="featured-poem textured container">
+  <h2>Featured Poem</h2>
+  <div class="poem">
+    Whispers curl like ivy round the stone,<br>
+    Night gardens breathe in royal purple tone,<br>
+    Gold dust settles on the page alone.
   </div>
 </section>
 
-<section class="portfolio container">
-  <h2>Portfolio</h2>
-  <p><!-- PORTFOLIO INTRO: 1 sentence: styles, spaces, results. --></p>
-  <div class="grid thumbs">
-    <figure class="thumb">
-      <img src="assets/social-share.jpg" alt="<!-- Replace with project alt text -->" loading="lazy" width="600">
-      <figcaption><!-- Project title --></figcaption>
-    </figure>
-    <figure class="thumb">
-      <img src="assets/social-share.jpg" alt="<!-- Replace with project alt text -->" loading="lazy" width="600">
-      <figcaption><!-- Project title --></figcaption>
-    </figure>
-    <figure class="thumb">
-      <img src="assets/social-share.jpg" alt="<!-- Replace with project alt text -->" loading="lazy" width="600">
-      <figcaption><!-- Project title --></figcaption>
-    </figure>
+<section class="latest-blog container">
+  <div><img src="assets/social-share.jpg" alt=""></div>
+  <div>
+    <h2>From the Journal</h2>
+    <p class="excerpt">Latest reflections on craft and inspiration.</p>
+    <a class="text-link" href="blog.html">Read the blog</a>
   </div>
-  <p><a class="text-link" href="projects.html">See all projects</a></p>
+</section>
+
+<section class="signup gold-border">
+  <div class="container">
+    <h2>Join the Newsletter</h2>
+    <form class="signup-form">
+      <input type="email" aria-label="Email address" placeholder="Email address">
+      <button class="btn" type="submit">Subscribe</button>
+    </form>
+  </div>
 </section>
 
   </main>

--- a/kindly-kylie-starter-site-v2/poems.html
+++ b/kindly-kylie-starter-site-v2/poems.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Library | Kindly, Kylie</title>
+  <meta name="description" content="Explore Kindly, Kylie's collection of original poems.">
+  <link rel="icon" href="assets/favicon.ico">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png" sizes="180x180">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&family=Montserrat:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <header class="site-header">
+    <div class="container">
+      <a href="index.html" class="logo" aria-label="Go to home"></a>
+      <nav class="main-nav" aria-label="Primary">
+        <button class="menu-toggle" aria-controls="menu" aria-expanded="false">Menu</button>
+        <ul id="menu">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="poems.html">Library</a></li>
+          <li><a href="commissions.html">Commissions</a></li>
+          <li><a href="shop.html">Shop</a></li>
+          <li><a href="spoken-word.html">Spoken Word</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="page-hero container">
+      <h1>Poetry Library</h1>
+      <p>Browse the archive of verses and musings.</p>
+    </section>
+
+    <section class="container">
+      <ul class="grid" style="list-style:none; padding:0; margin:0 0 2rem 0">
+        <li><a class="text-link" href="#">All</a></li>
+        <li><a class="text-link" href="#">Love</a></li>
+        <li><a class="text-link" href="#">Nature</a></li>
+        <li><a class="text-link" href="#">Reflections</a></li>
+      </ul>
+      <div class="grid cards">
+        <article class="card">
+          <h2 class="poem-title">Dawn</h2>
+          <div class="poem">Sunlight spills across the sill<br>and wakes the dreaming room.</div>
+        </article>
+        <article class="card">
+          <h2 class="poem-title">Nightfall</h2>
+          <div class="poem">Crickets sing to the moon<br>while shadows braid the sky.</div>
+        </article>
+        <article class="card">
+          <h2 class="poem-title">Memory</h2>
+          <div class="poem">I found your note between the pages<br>a pressed leaf, still green.</div>
+        </article>
+        <article class="card">
+          <h2 class="poem-title">Autumn</h2>
+          <div class="poem">Leaves whisper in the gallery<br>framed in antique gold.</div>
+        </article>
+      </div>
+    </section>
+
+    <section class="container textured card">
+      <h2>Poem of the Month</h2>
+      <div class="poem">
+        In quiet stacks the secrets keep,<br>
+        Ivy dreams and parchment sleep.<br>
+        A golden rhyme for hearts to steep.
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="signature">
+        <picture>
+          <source srcset="assets/signature-kindly-kylie-800.webp 800w, assets/signature-kindly-kylie-400.webp 400w" type="image/webp">
+          <img src="assets/signature-kindly-kylie-400.jpg" alt="Kindly, Kylie signature" loading="lazy" width="400">
+        </picture>
+      </div>
+      <small>&copy; Kindly, Kylie</small>
+    </div>
+  </footer>
+
+  <script src="js/main.js" defer></script>
+</body>
+</html>

--- a/kindly-kylie-starter-site-v2/shop.html
+++ b/kindly-kylie-starter-site-v2/shop.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Shop | Kindly, Kylie</title>
+  <meta name="description" content="Purchase handwritten poems and pre-order the upcoming book.">
+  <link rel="icon" href="assets/favicon.ico">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png" sizes="180x180">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&family=Montserrat:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <header class="site-header">
+    <div class="container">
+      <a href="index.html" class="logo" aria-label="Go to home"></a>
+      <nav class="main-nav" aria-label="Primary">
+        <button class="menu-toggle" aria-controls="menu" aria-expanded="false">Menu</button>
+        <ul id="menu">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="poems.html">Library</a></li>
+          <li><a href="commissions.html">Commissions</a></li>
+          <li><a href="shop.html">Shop</a></li>
+          <li><a href="spoken-word.html">Spoken Word</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="page-hero container">
+      <h1>Shop</h1>
+      <p>Handwritten poems and the forthcoming collection.</p>
+    </section>
+
+    <section class="container" style="display:grid;gap:2rem">
+      <div class="grid" style="grid-template-columns:1fr 1fr;gap:2rem;align-items:center;">
+        <div><img src="assets/social-share.jpg" alt="Handwritten poem"/></div>
+        <div>
+          <h2>Handwritten &amp; Signed Poems</h2>
+          <p>Each piece inked on textured paper.</p>
+        </div>
+      </div>
+      <div class="card textured">
+        <h2>Book Pre-order</h2>
+        <p>The debut collection arrives 2027.</p>
+        <a class="btn" href="#">Reserve your copy</a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="signature">
+        <picture>
+          <source srcset="assets/signature-kindly-kylie-800.webp 800w, assets/signature-kindly-kylie-400.webp 400w" type="image/webp">
+          <img src="assets/signature-kindly-kylie-400.jpg" alt="Kindly, Kylie signature" loading="lazy" width="400">
+        </picture>
+      </div>
+      <small>&copy; Kindly, Kylie</small>
+    </div>
+  </footer>
+
+  <script src="js/main.js" defer></script>
+</body>
+</html>

--- a/kindly-kylie-starter-site-v2/spoken-word.html
+++ b/kindly-kylie-starter-site-v2/spoken-word.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Spoken Word | Kindly, Kylie</title>
+  <meta name="description" content="Book Kindly, Kylie for an intimate spoken word performance.">
+  <link rel="icon" href="assets/favicon.ico">
+  <link rel="apple-touch-icon" href="assets/apple-touch-icon.png" sizes="180x180">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&family=Montserrat:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <header class="site-header">
+    <div class="container">
+      <a href="index.html" class="logo" aria-label="Go to home"></a>
+      <nav class="main-nav" aria-label="Primary">
+        <button class="menu-toggle" aria-controls="menu" aria-expanded="false">Menu</button>
+        <ul id="menu">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="poems.html">Library</a></li>
+          <li><a href="commissions.html">Commissions</a></li>
+          <li><a href="shop.html">Shop</a></li>
+          <li><a href="spoken-word.html">Spoken Word</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="page-hero container">
+      <h1>Spoken Word</h1>
+      <p>Experience poetry performed live.</p>
+    </section>
+
+    <section class="container">
+      <div class="grid cards">
+        <article class="card">
+          <h2>Private Events</h2>
+          <p>Intimate readings for gatherings.</p>
+        </article>
+        <article class="card">
+          <h2>Workshops</h2>
+          <p>Interactive sessions on poetic craft.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="container" style="margin-top:2rem">
+      <div class="grid" style="grid-template-columns:1fr 1fr;gap:2rem">
+        <div>
+          <h2>Technical Needs</h2>
+          <p>Microphone, small stage, quiet room.</p>
+        </div>
+        <div>
+          <h2>Logistics</h2>
+          <p>Available worldwide; travel fees apply.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="container" style="margin-top:2rem">
+      <h2>Media</h2>
+      <div class="grid thumbs">
+        <figure class="thumb"><img src="assets/social-share.jpg" alt="Performance"/></figure>
+        <figure class="thumb"><img src="assets/social-share.jpg" alt="Performance"/></figure>
+      </div>
+    </section>
+
+    <section class="container" style="margin-top:2rem">
+      <form class="contact-form" action="mailto:you@yourdomain.com" method="post" enctype="text/plain">
+        <label>Name <input type="text" name="name" required></label>
+        <label>Email <input type="email" name="email" required></label>
+        <label>Event Details <textarea name="details" rows="5"></textarea></label>
+        <button class="btn" type="submit">Request Booking</button>
+      </form>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <div class="signature">
+        <picture>
+          <source srcset="assets/signature-kindly-kylie-800.webp 800w, assets/signature-kindly-kylie-400.webp 400w" type="image/webp">
+          <img src="assets/signature-kindly-kylie-400.jpg" alt="Kindly, Kylie signature" loading="lazy" width="400">
+        </picture>
+      </div>
+      <small>&copy; Kindly, Kylie</small>
+    </div>
+  </footer>
+
+  <script src="js/main.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- style with brand palette and typography for dark-academia feel
- build homepage with hero, feature panels, featured poem, blog teaser, and signup
- add library, commissions, shop, spoken word, blog, about, and contact pages with consistent nav

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68981ee4f4bc832a9c56a4477411cf17